### PR TITLE
Api para GeoJSON

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,5 +1,6 @@
 from marketplaces.models import Marketplace
 from rest_framework import serializers
+from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
 
 class MarketplaceSerializer(serializers.ModelSerializer):
@@ -43,3 +44,16 @@ class MarketplaceSerializer(serializers.ModelSerializer):
             "florist",
             "other_services",
         ]
+
+class GeoMarketplaceSerializer(GeoFeatureModelSerializer):
+    class Meta:
+        model = Marketplace
+        geo_field = "location"
+        fields = (
+            "name",
+            "province",
+            "canton",
+            "district",
+            "postal_code",
+            "address",
+        )

--- a/api/urls.py
+++ b/api/urls.py
@@ -4,6 +4,7 @@ from . import views
 
 router = routers.DefaultRouter()
 router.register(r"ferias", views.MarketplaceViewSet)
+router.register(r"geoferias", views.GeoMarketplaceViewSet, basename='geo_marketplace')
 
 urlpatterns = [
     path("", views.datos, name="datos"),

--- a/api/views.py
+++ b/api/views.py
@@ -3,6 +3,7 @@ from django.http import FileResponse
 from rest_framework import viewsets
 from marketplaces.models import Marketplace
 from .serializers import MarketplaceSerializer
+from .serializers import GeoMarketplaceSerializer
 from website.models import Text
 
 import pandas as pd
@@ -15,6 +16,10 @@ import io
 class MarketplaceViewSet(viewsets.ModelViewSet):
     queryset = Marketplace.objects.all().order_by("name")
     serializer_class = MarketplaceSerializer
+
+class GeoMarketplaceViewSet(viewsets.ModelViewSet):
+    queryset = Marketplace.objects.all().order_by("name")
+    serializer_class = GeoMarketplaceSerializer
 
 
 def datos(request):

--- a/ferias/settings.py
+++ b/ferias/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     "blog.apps.BlogConfig",
     "feed.apps.FeedConfig",
     "rest_framework",
+    'rest_framework_gis',
     "drf_spectacular",
     "django.contrib.admin",
     "django.contrib.auth",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 django
 python-decouple
 djangorestframework
+djangorestframework-gis
 drf-spectacular
 psycopg2-binary
 geopy


### PR DESCRIPTION
Ahora la ruta "datos/api/geoferias/" despliega un api con un GeoJSON, que tiene información de las ferias respecto a su ubicación.

IMPORTANTE: 
- El `ferias/settings.py` se modificó, por lo que se debe revisar bien antes de hacer merge.
- Se actualizó el `requirements.txt` para instalar un paquete, así que hay que volver a correrlo para que funcione.

Close #64 